### PR TITLE
Removes base64 from toString.

### DIFF
--- a/app/requestHandler.js
+++ b/app/requestHandler.js
@@ -357,7 +357,7 @@ RequestHandler.prototype._auth_token = function(public, tokenType, tokenValue, a
 				if(err) {
 					callback(err);
 				}
-				if(calcHash.toString('base64') === storedHash) {
+				if(calcHash.toString() === storedHash) {
 					isAuthorized = true;
 				}
 				callback(null, isAuthorized);


### PR DESCRIPTION
The pbkdf2 function already does this.

Fixes Qabel/qabel-core#246, if Qabel/qabel-core#227 is also merged.